### PR TITLE
fix: add new badges to README: contributors, weekly downloads, repo stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # pixlated
 
+![Contributors](https://img.shields.io/github/contributors/Bridgetamana/pixlated.svg?style=flat)
+![NPM Downloads](https://img.shields.io/npm/dw/pixlated?style=flat)
+![Repo Stars](https://img.shields.io/github/stars/Bridgetamana/pixlated?style=flat)
 ![NPM Version](https://img.shields.io/npm/v/pixlated?style=flat)
 ![npm bundle size](https://img.shields.io/bundlephobia/min/pixlated)
 


### PR DESCRIPTION
Adds the requested badges to the top of the README file:
- GitHub contributor count
- weekly downloads
- repo stars