### PR TITLE
fix: add copy button on code examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,10 @@
             <span class="value-display" id="intensityValue">0.3</span>
           </div>
           <div class="code-example">
-            <pre><code>&lt;pixlated-image
+            <button class="copy" type="button" title="Copy" data-for="pixlated-image">
+              Copy
+            </button>
+            <pre><code id="pixlated-image">&lt;pixlated-image
   src="photo.jpg"
   intensity="0.3"
   width="400"
@@ -206,7 +209,10 @@
             <span class="value-display" id="bgIntensityValue">0.15</span>
           </div>
           <div class="code-example">
-            <pre><code>&lt;pixlated-bg
+            <button class="copy" type="button" title="Copy" data-for="pixlated-bg">
+              Copy
+            </button>
+            <pre><code id="pixlated-bg">&lt;pixlated-bg
   intensity="0.15"
   color="#09090b"
 &gt;
@@ -287,6 +293,7 @@
       const intensityValue = document.getElementById("intensityValue");
       const bgIntensitySlider = document.getElementById("bgIntensitySlider");
       const bgIntensityValue = document.getElementById("bgIntensityValue");
+      const copyBtns = document.querySelectorAll("button.copy");
 
       const loadTheme = () => {
         const savedTheme = localStorage.getItem("theme");
@@ -322,6 +329,27 @@
         document.body.classList.add("dark");
         saveTheme(true);
       });
+      
+      copyBtns.forEach((copyBtn) => {
+        copyBtn.addEventListener("click", (e) => {
+          const btn = e.target;
+          if (btn.disabled) {
+            return;
+          }
+
+          // retrieve code element and copy content to clipboard
+          const code = document.querySelector(`#${btn.dataset.for}`);
+          navigator.clipboard.writeText(code.textContent);
+
+          // Let the user know that the content is copied
+          btn.disabled = true;
+          btn.textContent = "Copied!";
+          setTimeout(() => {
+            btn.textContent = "Copy";
+            btn.disabled = false;
+          }, 400);
+        })
+      })
     </script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -176,6 +176,20 @@
 
   .code-example {
     width: 100%;
+    position: relative;
+  }
+
+  .code-example button.copy {
+    background: var(--card-color);
+    color: var(--foreground-muted);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    position: absolute;
+    right: 5px;
+    top: 5px;
+    cursor: pointer;
+    padding: 4px 5px;
+    font-size: 0.75rem;
   }
 
   .code-example pre {


### PR DESCRIPTION
### **Description**

This PR is here for fixing [issue 11](https://github.com/Bridgetamana/pixlated/issues/11).
It's adding two buttons on code examples to copy content.

### **UI**

Here is a screenshot of the UI with the button.

<img width="1270" height="396" alt="screen1" src="https://github.com/user-attachments/assets/08fcdd9b-dc0a-49ad-afcc-d890cecb922a" />

And after user clicked on it.

<img width="1270" height="373" alt="screen3" src="https://github.com/user-attachments/assets/e7043dee-c6b2-4212-bf3f-f941834f5073" />