### PR TITLE
fix: improve theme toggle accessibility with button wrapper and focus…

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,46 +78,58 @@
         <div class="page-title">
           <h1>pixlated</h1>
           <div class="theme-btn">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              width="30"
-              height="30"
-              color="currentColor"
-              fill="none"
+            <button
               id="dark-toggle"
+              class="theme-toggle"
+              type="button"
               aria-label="Switch to light theme"
+              title="Switch to light theme"
             >
-              <path
-                d="M21.5 14.0784C20.3003 14.7189 18.9301 15.0821 17.4751 15.0821C12.7491 15.0821 8.91792 11.2509 8.91792 6.52485C8.91792 5.06986 9.28105 3.69968 9.92163 2.5C5.66765 3.49698 2.5 7.31513 2.5 11.8731C2.5 17.1899 6.8101 21.5 12.1269 21.5C16.6849 21.5 20.503 18.3324 21.5 14.0784Z"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              width="30"
-              height="30"
-              color="currentColor"
-              fill="none"
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                width="30"
+                height="30"
+                color="currentColor"
+                fill="none"
+              >
+                <path
+                  d="M21.5 14.0784C20.3003 14.7189 18.9301 15.0821 17.4751 15.0821C12.7491 15.0821 8.91792 11.2509 8.91792 6.52485C8.91792 5.06986 9.28105 3.69968 9.92163 2.5C5.66765 3.49698 2.5 7.31513 2.5 11.8731C2.5 17.1899 6.8101 21.5 12.1269 21.5C16.6849 21.5 20.503 18.3324 21.5 14.0784Z"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+            <button
               id="light-toggle"
+              class="theme-toggle"
+              type="button"
               aria-label="Switch to dark theme"
+              title="Switch to dark theme"
             >
-              <path
-                d="M17 12C17 14.7614 14.7614 17 12 17C9.23858 17 7 14.7614 7 12C7 9.23858 9.23858 7 12 7C14.7614 7 17 9.23858 17 12Z"
-                stroke="currentColor"
-                stroke-width="1.5"
-              ></path>
-              <path
-                d="M12 2C11.6227 2.33333 11.0945 3.2 12 4M12 20C12.3773 20.3333 12.9055 21.2 12 22M19.5 4.50271C18.9685 4.46982 17.9253 4.72293 18.0042 5.99847M5.49576 17.5C5.52865 18.0315 5.27555 19.0747 4 18.9958M5.00271 4.5C4.96979 5.03202 5.22315 6.0763 6.5 5.99729M18 17.5026C18.5315 17.4715 19.5747 17.7108 19.4958 18.9168M22 12C21.6667 11.6227 20.8 11.0945 20 12M4 11.5C3.66667 11.8773 2.8 12.4055 2 11.5"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-              ></path>
-            </svg>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                width="30"
+                height="30"
+                color="currentColor"
+                fill="none"
+              >
+                <path
+                  d="M17 12C17 14.7614 14.7614 17 12 17C9.23858 17 7 14.7614 7 12C7 9.23858 9.23858 7 12 7C14.7614 7 17 9.23858 17 12Z"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                ></path>
+                <path
+                  d="M12 2C11.6227 2.33333 11.0945 3.2 12 4M12 20C12.3773 20.3333 12.9055 21.2 12 22M19.5 4.50271C18.9685 4.46982 17.9253 4.72293 18.0042 5.99847M5.49576 17.5C5.52865 18.0315 5.27555 19.0747 4 18.9958M5.00271 4.5C4.96979 5.03202 5.22315 6.0763 6.5 5.99729M18 17.5026C18.5315 17.4715 19.5747 17.7108 19.4958 18.9168M22 12C21.6667 11.6227 20.8 11.0945 20 12M4 11.5C3.66667 11.8773 2.8 12.4055 2 11.5"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                ></path>
+              </svg>
+            </button>
           </div>
         </div>
         <div class="description-container">

--- a/style.css
+++ b/style.css
@@ -342,7 +342,8 @@
     height: 32px;
   }
 
-  .theme-btn svg {
+  /* Buttons now wrap the SVGs: style the button and svg appropriately */
+  .theme-btn .theme-toggle {
     position: absolute;
     top: 0;
     left: 0;
@@ -352,29 +353,45 @@
     border-radius: var(--radius-lg);
     background-color: var(--card-color);
     border: 1px solid var(--border-color);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
   }
 
-  .theme-btn svg:hover {
+  .theme-btn .theme-toggle:hover {
     background-color: var(--card-color-darker);
   }
 
-  #dark-toggle {
+  .theme-btn .theme-toggle svg {
+    color: var(--foreground);
+  }
+
+  /* Visible/hidden toggle buttons (IDs are now on the buttons) */
+  .theme-btn #dark-toggle {
     opacity: 0;
     pointer-events: none;
   }
 
-  body.dark #dark-toggle {
+  body.dark .theme-btn #dark-toggle {
     opacity: 1;
     pointer-events: auto;
   }
 
-  body.dark #light-toggle {
+  body.dark .theme-btn #light-toggle {
     opacity: 0;
     pointer-events: none;
   }
 
-  .theme-btn svg.rotate {
+  /* Rotation helper: cover svg.rotate inside button or rotate button itself */
+  .theme-btn .theme-toggle svg.rotate,
+  .theme-btn .theme-toggle.rotate svg {
     transform: rotate(360deg);
+  }
+
+  /* Keyboard focus for accessibility */
+  .theme-btn .theme-toggle:focus-visible {
+    outline: 2px solid var(--foreground);
+    outline-offset: 2px;
   }
 
   .demo-bg {


### PR DESCRIPTION
## Problem
The theme toggle buttons were using raw SVG elements, causing accessibility issues:
- Not focusable with keyboard
- Not keyboard-accessible (can't activate with Enter/Space)
- Not recognized by screen readers

## Solution
- Wrap SVGs in \`<button>\` elements for proper semantic HTML
- Move IDs from SVG to button elements
- Add \`aria-label\` and \`title\` attributes for screen reader support
- Add \`:focus-visible\` CSS styles for keyboard focus indication
- Ensure SVG color uses foreground color for proper theme contrast in both light and dark modes

## Changes Made
1. **index.html**: Wrapped each theme toggle SVG in a \`<button>\` with proper ARIA attributes
2. **style.css**: 
   - Updated selectors to target \`.theme-btn .theme-toggle\` (buttons)
   - Added \`:focus-visible\` styles for keyboard focus
   - Added SVG color rule for proper theme contrast

## Testing
- Keyboard navigation: Tab key now focuses the buttons
-  Keyboard activation: Enter/Space now toggles theme
-  Screen readers: aria-label announces 'Switch to light/dark theme'
-  Visual focus: Focus outline visible when tabbing through buttons
-  Theme contrast: SVG icons visible in both light and dark modes"

