### PR TITLE
Replace attributes section with a table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ Add noise texture to images:
 
 **Attributes:**
 
-| Attribute | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `src` | string | required | Image URL|
-| `intensity` | float | 0.1 | Noise intensity from 0 to 1 |
-| `width` | int | 400 | Canvas width in pixels |
-| `height` | int | 400 | Canvas height in pixels |
-| `alt` | string | optional | Alternative text for accessibility |
+| Attribute | Default | Description |
+|-----------|---------|-------------|
+| `src`  | required | Image URL|
+| `intensity`  | 0.1 | Noise intensity from 0 to 1 |
+| `width`  | 400 | Canvas width in pixels |
+| `height`  | 400 | Canvas height in pixels |
+| `alt`  | optional | Alternative text for accessibility |
 
 ### Background Noise Effect
 
@@ -75,10 +75,12 @@ Add noise texture to backgrounds:
 
 **Attributes:**
 
-- `intensity` (optional) - Noise intensity from 0 to 1 (default: 0.1)
-- `color` (optional) - Background color (default: #09090b)
-- `width` (optional) - Fixed width in pixels (auto-sizes by default)
-- `height` (optional) - Fixed height in pixels (auto-sizes by default)
+| Attribute | Default | Description |
+|-----------|---------|-------------|
+| `intensity` | 0.1 | Noise intensity from 0 to 1
+| `color` | #09090b | Background color
+| `width` | auto-sizes | Fixed width in pixels |
+| `height` | auto-sizes | Fixed height in pixels 
 
 ### Styling
 


### PR DESCRIPTION
## Description

The attributes section in the README was reformatted from plain text to a table.

Fixes #28 

The attributes section has been formatted into a table that shows each attribute, default values (if applicable), and a description.

